### PR TITLE
updated handleOpen to nondeprecated function

### DIFF
--- a/app/getting-started-ios-sdk/AppDelegate.swift
+++ b/app/getting-started-ios-sdk/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-    func application(_ application: UIApplication, handleOpen url: URL) -> Bool {
+    func application(_ application: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
         window!.rootViewController?.presentedViewController?.dismiss(animated: true , completion: nil)
         smartcar!.handleCallback(with: url)
         

--- a/tutorial/getting-started-ios-sdk/AppDelegate.swift
+++ b/tutorial/getting-started-ios-sdk/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-    func application(_ application: UIApplication, handleOpen url: URL) -> Bool {
+    func application(_ application: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
         // TODO: Authorization Step 3a: Receive an authorization code
         
         return true


### PR DESCRIPTION
handleOpen is deprecated function in IOS. I was able to reproduce hanging error using handleOpen and remove error when using new function: open url
https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application